### PR TITLE
Rename "Exercises" to "Problems" in chapter 5

### DIFF
--- a/ant-chapters/chapter5.tex
+++ b/ant-chapters/chapter5.tex
@@ -344,8 +344,7 @@ However, $p\nmid |C(\Z[\ze_p])|$ so $C(\Z[\ze_p])$ has no $p$-torsion. Since $(x
 a_j=\ze_p^{r_j}v_j,\quad v_j\in \Q[\ze_p]^+.
 \] 
 \end{proof}
-\section{Exercises}
-\noindent \textbf{Problems}
+\section{Problems}
 \begin{enumerate}
 \item[1.1] Let $p$ be a prime. Prove that any equiangular $p$-gon with rational side lengths is regular.
 


### PR DESCRIPTION
In all other chapters, the exercise section is called "Problems". This commit fixes this inconsistency.

This is intentionally a trivial PR. I'm currently reading parts of the book and I wonder if I should submit patches for the things I notice. With no commits in 5 years, and no third-party commits, the project may currently be dead, so I'm testing the waters before investing my time in sending more patches.